### PR TITLE
Fix compiler expansion for hashtag-like strings

### DIFF
--- a/lib/compiler/Expand.ml
+++ b/lib/compiler/Expand.ml
@@ -41,7 +41,9 @@ let rec expand_eff ~(forest : State.t) : Code.t -> Syn.t = function
   | node :: rest ->
     entered_range node.loc;
     match node.value with
-    | Hash_ident x | Text x ->
+    | Hash_ident x ->
+      {node with value = Text ("#" ^ x)} :: expand_eff ~forest rest
+    | Text x ->
       {node with value = Text x} :: expand_eff ~forest rest
     | Verbatim x ->
       {node with value = Verbatim x} :: expand_eff ~forest rest

--- a/lib/frontend/DSL.ml
+++ b/lib/frontend/DSL.ml
@@ -96,6 +96,7 @@ module Code = struct
   let braces = Fun.compose (locate_opt None) @@ Code.braces
 
   let ident i = locate_opt None @@ Ident i
+  let hash_ident str = locate_opt None @@ Hash_ident str
 
   let ul = ident ["ul"]
   let li = ident ["li"]

--- a/lib/parser/test/Test_parser.ml
+++ b/lib/parser/test/Test_parser.ml
@@ -108,6 +108,12 @@ let test_math () =
     )
     (parse_string_no_loc {|##{a^2 + b^2 = c^2}|})
 
+let test_hashtag () =
+  Alcotest.(check @@ result code diagnostic)
+    "same nodes"
+    (Ok [hash_ident "abc"])
+    (parse_string_no_loc {|#abc|})
+
 let test_object () =
   Alcotest.(check @@ result code diagnostic)
     "same nodes"
@@ -144,5 +150,6 @@ let () =
       "text", [test_case "text" `Quick test_prim];
       "verbatim", [test_case "verbatim" `Quick test_verbatim];
       "math", [test_case "math" `Quick test_math];
+      "hashtag", [test_case "hashtag" `Quick test_hashtag];
       "object", [test_case "object" `Quick test_object];
     ]


### PR DESCRIPTION
`#abc` was rendered as `abc`, now rendered as is.

The fix applies to all clients.

Closes: https://todo.sr.ht/~jonsterling/forester/188